### PR TITLE
Remove getDOMNode(), deprecated and not required anymore

### DIFF
--- a/src/react-drive-in.jsx
+++ b/src/react-drive-in.jsx
@@ -24,7 +24,7 @@ class ReactDriveIn extends React.Component {
   }
 
   getMedia() {
-    return this.refs.media.getDOMNode();
+    return this.refs.media;
   }
 
   getPlaylist() {


### PR DESCRIPTION
https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#dom-node-refs